### PR TITLE
Update c14m2 files

### DIFF
--- a/scripts/vscripts/c14m2_gauntlet.nut
+++ b/scripts/vscripts/c14m2_gauntlet.nut
@@ -2,17 +2,17 @@ Msg("Beginning Lighthouse Scavenge.\n")
 
 DirectorOptions <-
 {
-	CommonLimit = 15
+	CommonLimit = 7
 	MobSpawnMinTime = 8
-	MobSpawnMaxTime = 12
-	MobSpawnSize = 7
-	MobMaxPending = 12
+	MobSpawnMaxTime = 16
+	MobSpawnSize = 4
+	MobMaxPending = 10
 	IntensityRelaxThreshold = 0.99
-	RelaxMinInterval = 2
-	RelaxMaxInterval = 4
-	SustainPeakMinTime = 25
-	SustainPeakMaxTime = 30
-	SpecialRespawnInterval = 30
+	RelaxMinInterval = 3
+	RelaxMaxInterval = 5
+	SustainPeakMinTime = 8
+	SustainPeakMaxTime = 16
+	SpecialRespawnInterval = 40
 	LockTempo = false
 	PreferredMobDirection = SPAWN_ANYWHERE
 	PanicForever = true
@@ -20,12 +20,7 @@ DirectorOptions <-
 
 if ( Director.IsSinglePlayerGame() )
 {
-	DirectorOptions.CommonLimit = 10;
-	DirectorOptions.MobSpawnSize = 5;
-	DirectorOptions.MobMaxPending = 8;
+    DirectorOptions.IntensityRelaxThreshold <- 0.94
 }
-
-if ( Director.GetGameModeBase() == "versus" )
-	DirectorOptions.MobSpawnSize = 4;
 
 Director.ResetMobTimer();

--- a/scripts/vscripts/c14m2_gauntlet_vs.nut
+++ b/scripts/vscripts/c14m2_gauntlet_vs.nut
@@ -1,16 +1,16 @@
 DirectorOptions <-
 {
-	CommonLimit = 10
+	CommonLimit = 15
 	MobSpawnMinTime = 8
-	MobSpawnMaxTime = 12
-	MobSpawnSize = 5
-	MobMaxPending = 8
+	MobSpawnMaxTime = 16
+	MobSpawnSize = 10
+	MobMaxPending = 10
 	IntensityRelaxThreshold = 0.99
-	RelaxMinInterval = 2
-	RelaxMaxInterval = 4
-	SustainPeakMinTime = 25
-	SustainPeakMaxTime = 30
-	SpecialRespawnInterval = 30
+	RelaxMinInterval = 3
+	RelaxMaxInterval = 5
+	SustainPeakMinTime = 8
+	SustainPeakMaxTime = 16
+	SpecialRespawnInterval = 40
 	LockTempo = false
 	PreferredMobDirection = SPAWN_ANYWHERE
 	PanicForever = true

--- a/scripts/vscripts/c14m2_lighthouse_finale.nut
+++ b/scripts/vscripts/c14m2_lighthouse_finale.nut
@@ -36,53 +36,61 @@ DirectorOptions <-
 	ProhibitBosses = true
 	HordeEscapeCommonLimit = 20
 	EscapeSpawnTanks = false
-	CommonLimit = 25
+	SpecialRespawnInterval = 25
 }
 
 local difficulty = GetDifficulty();
+local gascanDifficulty = GetDifficulty();
 
 if ( Director.GetGameModeBase() == "versus" )
 {
-	DirectorOptions.rawdelete("A_CustomFinaleMusic7");
-	DirectorOptions.A_CustomFinale_StageCount = 11;
-	DirectorOptions.A_CustomFinale6 = ONSLAUGHT;
-	DirectorOptions.A_CustomFinaleValue6 = "c14m2_gauntlet_vs";
-	DirectorOptions.A_CustomFinale7 = ONSLAUGHT;
-	DirectorOptions.A_CustomFinaleValue7 = "c14m2_gauntlet_vs";
-	DirectorOptions.A_CustomFinale8 = ONSLAUGHT;
-	DirectorOptions.A_CustomFinaleValue8 = "c14m2_gauntlet_vs";
-	DirectorOptions.A_CustomFinale9 <- DELAY;
-	DirectorOptions.A_CustomFinaleValue9 <- StageDelay;
-	DirectorOptions.A_CustomFinale10 <- TANK;
-	DirectorOptions.A_CustomFinaleValue10 <- 1;
-	DirectorOptions.A_CustomFinaleMusic10 <- "Event.TankMidpoint_Metal";
-	DirectorOptions.A_CustomFinale11 <- DELAY;
-	DirectorOptions.A_CustomFinaleValue11 <- PreEscapeDelay;
+    DirectorOptions.rawdelete("A_CustomFinaleMusic7");
+    DirectorOptions.A_CustomFinale_StageCount = 11;
+    DirectorOptions.A_CustomFinale6 = ONSLAUGHT;
+    DirectorOptions.A_CustomFinaleValue6 = "c14m2_gauntlet_vs";
+    DirectorOptions.A_CustomFinale7 = ONSLAUGHT;
+    DirectorOptions.A_CustomFinaleValue7 = "c14m2_gauntlet_vs";
+    DirectorOptions.A_CustomFinale8 = ONSLAUGHT;
+    DirectorOptions.A_CustomFinaleValue8 = "c14m2_gauntlet_vs";
+    DirectorOptions.A_CustomFinale9 <- DELAY;
+    DirectorOptions.A_CustomFinaleValue9 <- StageDelay;
+    DirectorOptions.A_CustomFinale10 <- TANK;
+    DirectorOptions.A_CustomFinaleValue10 <- 1;
+    DirectorOptions.A_CustomFinaleMusic10 <- "Event.TankMidpoint_Metal";
+    DirectorOptions.A_CustomFinale11 <- DELAY;
+    DirectorOptions.A_CustomFinaleValue11 <- PreEscapeDelay;
 	difficulty = 1;
+    gascanDifficulty = 1;
 }
 else
 {
-	if ( difficulty == 2 || difficulty == 3 )
-	{
-		DirectorOptions.rawdelete("A_CustomFinaleMusic7");
-		DirectorOptions.A_CustomFinale_StageCount = 12;
-		DirectorOptions.A_CustomFinaleValue7 = 1;
-		DirectorOptions.A_CustomFinaleValue8 = StageDelay;
-		DirectorOptions.A_CustomFinale9 <- PANIC;
-		DirectorOptions.A_CustomFinaleValue9 <- 2;
-		DirectorOptions.A_CustomFinale10 <- DELAY;
-		DirectorOptions.A_CustomFinaleValue10 <- StageDelay;
-		DirectorOptions.A_CustomFinale11 <- TANK;
-		DirectorOptions.A_CustomFinaleValue11 <- 2;
-		DirectorOptions.A_CustomFinaleMusic11 <- "Event.TankMidpoint_Metal"
-		DirectorOptions.A_CustomFinale12 <- DELAY;
-		DirectorOptions.A_CustomFinaleValue12 <- PreEscapeDelay;
-	}
+    if ( difficulty == 2 || difficulty == 3 )
+    {
+        DirectorOptions.rawdelete("A_CustomFinaleMusic7");
+        DirectorOptions.A_CustomFinale_StageCount = 12;
+        DirectorOptions.A_CustomFinaleValue7 = 1;
+        DirectorOptions.A_CustomFinaleValue8 = StageDelay;
+        DirectorOptions.A_CustomFinale9 <- PANIC;
+        DirectorOptions.A_CustomFinaleValue9 <- 2;
+        DirectorOptions.A_CustomFinaleMusic9 <- "Event.FinaleWave4"
+        DirectorOptions.A_CustomFinale10 <- DELAY;
+        DirectorOptions.A_CustomFinaleValue10 <- StageDelay;
+        DirectorOptions.A_CustomFinale11 <- TANK;
+        DirectorOptions.A_CustomFinaleValue11 <- 2;
+        DirectorOptions.A_CustomFinaleMusic11 <- "Event.TankMidpoint_Metal"
+        DirectorOptions.A_CustomFinale12 <- DELAY;
+        DirectorOptions.A_CustomFinaleValue12 <- PreEscapeDelay;
+        gascanDifficulty = 3;
+    }
+    else
+    {
+        gascanDifficulty = 1;
+    }
 }
 
 //-----------------------------------------------------
 
-function SpawnScavengeCans( difficulty )
+function SpawnScavengeCans( gascanDifficulty )
 {
 	local function SpawnCan( gascan )
 	{
@@ -116,7 +124,7 @@ function SpawnScavengeCans( difficulty )
 			DoEntFire( "!self", "SpawnItem", "", 0, null, can_spawner );
 	}
 	
-	switch( difficulty )
+	switch( gascanDifficulty )
 	{
 		case 3:
 		{
@@ -169,7 +177,7 @@ switch( difficulty )
 {
 	case 0:
 	{
-		NumCansNeeded = 6;
+		NumCansNeeded = 8;
 		EntFire( "relay_outro_easy", "Enable" );
 		break;
 	}
@@ -181,7 +189,7 @@ switch( difficulty )
 	}
 	case 2:
 	{
-		NumCansNeeded = 10;
+		NumCansNeeded = 12;
 		EntFire( "relay_outro_advanced", "Enable" );
 		break;
 	}
@@ -195,8 +203,15 @@ switch( difficulty )
 		break;
 }
 
-if ( Director.IsSinglePlayerGame() )
+if ( Director.IsSinglePlayerGame() && difficulty < 2 )
+{
 	NumCansNeeded -= 2;
+}
+else if ( Director.IsSinglePlayerGame() && difficulty > 1 )
+{
+	NumCansNeeded -= 3;
+}
+
 
 EntFire( "progress_display", "SetTotalItems", NumCansNeeded );
 EntFire( "radio", "AddOutput", "FinaleEscapeStarted director:RunScriptCode:DirectorScript.MapScript.LocalScript.DirectorOptions.TankLimit <- 3:0:-1" );
@@ -253,6 +268,12 @@ function GasCanTouched()
 	GasCansTouched++;
 	if ( developer() > 0 )
 		Msg(" Touched: " + GasCansTouched + "\n");
+
+	if ( GasCansTouched >= 1 )
+	{
+		DirectorOptions.CommonLimit <- 15;
+		DirectorOptions.MobSpawnSize <- 10;
+	}
 }
 
 function GasCanPoured()
@@ -310,7 +331,7 @@ function OnBeginCustomFinaleStage( num, type )
 	else if ( num == 5 )
 	{
 		EntFire( "relay_lighthouse_off", "Trigger" );
-		SpawnScavengeCans( difficulty );
+		SpawnScavengeCans( gascanDifficulty );
 	}
 	else if ( num == EscapeStage )
 		EntFire( "relay_start_boat", "Trigger" );


### PR DESCRIPTION
* Adjusted difficulty scaling for the number of gascans during the scavenge section. The gacan requirement in Multiplayer modes will now increase by 1.5x on Advanced/Expert difficulties instead of each individual difficulty increasing it by 2. Easy/Normal will now require survivors to collect 8 gascans, and Advanced/Expert will require 12.
* Lowered the number of gascans required to fill the generator in Singleplayer by 25%. Easy/Normal will now require survivors to collect 6 gascans, and Advanced/Expert will require 9.
* Changed LockTempo from TRUE to FALSE during the Scavenge phase. This will allow the director to use SUSTAIN_PEAK, RELAX, BUILD_UP phases instead of being locked into a COMBAT phase. The COMBAT phase forces the director to continually spawn commons based on a timer regardless of what the survivors intensity is. This change will let the director tone down the horde when survivor intensity gets too high (e.g. survivors getting downed) which will let the director pace the horde based on the survivors performance.
* Changed the start of the Scavenge phase to spawn less horde until players start picking up the gascans.
* Decreased CommonLimit from 15 to 7 at the start of the Scavenge phase. After picking up a gascan CommonLimit is increased to 15.
* Decreased MobSpawnSize from 7 to 4 at the start of the Scavenge phase. After picking up a gascan MobSpawnSize is increased to 10.
* Increased MobSpawnMaxTime from 12 to 16 during the Scavenge phase.
* Decreased MobMaxPending from 12 to 10 during the Scavenge phase.
* Added RelaxMinInterval/RelaxMaxInterval which are set to 3/5 during the Scavenge phase.
* Added SustainPeakMinTime/SustainPeakMaxTime which are set to 8/16 during the Scavenge phase.
* Added IntensityRelaxThreshold which is set to 0.99 during the Scavenge phase in Multiplayer modes, and in Singleplayer this is set to 0.94.
* Removed the decreased CommonLimit, MobSpawnSize, and MobMaxPending during the Scavenge phase for Singleplayer mode. These values will now be consistent with other modes.
* Removed the decreased MobSpawnSize during the Scavenge phase in Versus mode. This value will now be consistent with other modes.
* Changed the c14m2_gauntlet_vs script DirectorOptions to be consistent with the c14m2_gauntlet script.
* Increased SpecialRespawnInterval from 30 to 40 during the Scavenge phase.
* Increased SpecialRespawnInterval from 20 to 25 during the Holdout phases.
* Added the Final Nail music before the last horde phase on Advanced/Expert difficulties.