### PR TITLE
Changelog edits - Knife, Dark Carnival

### DIFF
--- a/changelogs/Hotfix_Update_01.md
+++ b/changelogs/Hotfix_Update_01.md
@@ -27,8 +27,8 @@ This changelog comprehensively summarizes all differences from the live game to 
 
 ### Weapons:
 
-&emsp;[+](https://github.com/L4D-Community-Team/Last-Stand-Refresh/blob/main/scripts/melee/knife.txt#L91) Knife slash pattern goes from left to right (W2E) instead of left to bottom-right (W2SE) to restore its old behavior. `[knife.txt]`<br/>
-&emsp;[+](https://github.com/L4D-Community-Team/Last-Stand-Refresh/blob/main/scripts/melee/knife.txt#L96-L97) Knife world animations now swing in the same direction as the viewmodel's. `[knife.txt]`<br/>
+&emsp;[+](https://github.com/L4D-Community-Team/Last-Stand-Refresh/blob/main/scripts/melee/knife.txt#L91) Knife's slash pattern is restored to its old behavior, going from left to right instead of left to bottom-right. `[knife.txt]`<br/>
+&emsp;[+](https://github.com/L4D-Community-Team/Last-Stand-Refresh/blob/main/scripts/melee/knife.txt#L96-L97) Knife's world animations no longer swings in the direction opposite to the viewmodel's. `[knife.txt]`<br/>
 
 ### Effects:
 
@@ -87,7 +87,15 @@ This changelog comprehensively summarizes all differences from the live game to 
 
 #### Map 5:
 
-&emsp;[+](https://github.com/L4D-Community-Team/Last-Stand-Refresh/commit/d54a5911e92d75ebb1e8c88ac9120cf7da4f8933) Fixed issue where THE MAIN ATTRACTION Achievement would not unlock if a player disconnects or idles while in the trigger; added multiple trigger volumes that detect if a Survivor leaves the stage instead of only one that checked if a Survivor stopped touching it.<br/>
+&emsp;[+](https://github.com/L4D-Community-Team/Last-Stand-Refresh/commit/d54a5911e92d75ebb1e8c88ac9120cf7da4f8933) Addressed several issues in attaining the `THE MAIN ATTRACTION` achievement:<br/>
+&emsp;&emsp;- Fixed the achievement failing for all survivors if any of them disconnects or idles while on the stage.<br/>
+&emsp;&emsp;- Fixed the achievement being attained without ever getting on the stage.
+<!--
+Technical detail is interesting to modders, but is too busy to everyone else:
+
+1. Added multiple trigger volumes that detect if a Survivor leaves the stage instead of only one that checked if a Survivor stopped touching it.
+2. The FAILED state persists through map resets... too bad!
+-->
 
 ### Swamp Fever
 


### PR DESCRIPTION
## 1) Weapons > Knife
A disclaimer, these may be simply be based on personal preference.

### A)
```
- Knife slash pattern goes from left to right (W2E) instead of left to bottom-right (W2SE) to restore its old behavior.
+ Knife's slash pattern is restored to its old behavior, going from left to right instead of left to bottom-right.
```
The idea is to restore the Knife's old behavior, so I've moved that to the front and exact details to the back. I also removed the acronyms in brackets since they noisily and showily repeat the same idea in a different manner.

### B)
```
- Knife world animations now swing in the same direction as the viewmodel's.
+ Knife's world animations no longer swings in the direction opposite to the viewmodel's.
```
Negated the sentence to add the idea that something is being removed rather than just something being added, which I believe attracts more attention.

## 2) Dark Carnival > Map 5

### A)
```
- Fixed issue where THE MAIN ATTRACTION Achievement would not unlock if a player disconnects or idles while in the trigger; added multiple trigger volumes that detect if a Survivor leaves the stage instead of only one that checked if a Survivor stopped touching it
+ Addressed several issues in attaining the `THE MAIN ATTRACTION` achievement:<br/>
+   - Fixed the achievement failing for all survivors if any of them disconnects or idles while on the stage.<br/>
+   - Fixed the achievement being attained without ever getting on the stage.
```
1. Omitted both the technical details and terms from public view as that doesn't aid with understanding the idea of the change; I've moved the technical details to a Markdown comment.
2. Added an extra note that states the other main reason of changing the method to handle the achievement's voiding.